### PR TITLE
Adding Code of Conduct based on Ruby's CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+This document provides community guidelines for a safe, respectful, productive, and collaborative place for any person who is willing to contribute to the Ruby community. It applies to all “collaborative space”, which is defined as community communications channels (such as mailing lists, submitted patches, commit comments, etc.).
+
+ * Participants will be tolerant of opposing views.
+ * Participants must ensure that their language and actions are free of personal attacks and disparaging personal remarks.
+ * When interpreting the words and actions of others, participants should always assume good intentions.
+ * Behaviour which can be reasonably considered harassment will not be tolerated.
+
+ Adopted from the [Ruby Code of Conduct](https://www.ruby-lang.org/en/conduct/)


### PR DESCRIPTION
Per Issue #17, adopting a Code of Conduct based on [Ruby's CoC](https://www.ruby-lang.org/en/conduct/)
